### PR TITLE
firebase fixes

### DIFF
--- a/client/src/components/ItemCard.js
+++ b/client/src/components/ItemCard.js
@@ -66,7 +66,8 @@ const ItemCard = (props) => {
 
   function whichTimer(){
     let normal=normalTimer-Date.now()+offset
-    let quick=quickTimer-Date.now()+offset
+    let quick=quickTimer-Date.now()+offsetgit
+    console.log(normal,quick)
     if(normal>0){
      return ["normal",normalTimer+offset]
     }

--- a/client/src/components/TimeWatch/ReactTimerStopwatch.js
+++ b/client/src/components/TimeWatch/ReactTimerStopwatch.js
@@ -54,7 +54,7 @@ const ReactTimerStopwatch = (props) => {
 
   useEffect(() => {
     if(ready){
-     stopWatch.current=setInterval(counter)
+     stopWatch.current=setInterval(counter,500)
     }
     else{
      setText("00:00:00")
@@ -65,8 +65,8 @@ const ReactTimerStopwatch = (props) => {
  //setinterval can't detect changes on its own
 useEffect(() => {
 clearInterval(stopWatch.current)
-stopWatch.current=setInterval(counter)
-}, [quickTimer]);
+stopWatch.current=setInterval(counter,500)
+}, [quickTimer,normalTimer]);
 
 
     return (


### PR DESCRIPTION
The normaltimer should not be changed normally, but I added it to the useeffect anyways. That way if the value is changed in firebase it will be relected in the timer right away. Otherwise you have to reload the page. 

Also more importantly added an interval to the set interval function. 500 ms should be a good split I think